### PR TITLE
☀️  IPFS unpinning

### DIFF
--- a/BFF/ipfs/unpin.ts
+++ b/BFF/ipfs/unpin.ts
@@ -1,0 +1,20 @@
+import pinataSDK from "@pinata/sdk";
+
+import dotenv from "dotenv";
+dotenv.config();
+
+export async function unpin({ hash }: { hash: string }) {
+  console.log("hash", hash);
+  const PINATA_KEY = process.env.PINATA_KEY;
+  const PINATA_SECRET_KEY = process.env.PINATA_SECRET_KEY;
+
+  const pinata = new pinataSDK(PINATA_KEY, PINATA_SECRET_KEY);
+
+  try {
+    const result = await pinata.unpin(hash);
+    return result;
+  } catch (error) {
+    console.error("Error unpinning file on IPFS:", error);
+    return { mediaError: "Internal Server Error" };
+  }
+}

--- a/components/ComingSoon.tsx
+++ b/components/ComingSoon.tsx
@@ -1,0 +1,28 @@
+import { Box, Flex, Heading, Text, Image } from "@chakra-ui/react";
+
+const ComingSoon = () => {
+  const Logo = () => {
+    return (
+      <Flex align="center" ml={5} mt={5}>
+        <Image src={"/pig_logo.png"} alt="Loader" width="50" height="50" />
+        <Heading size="lg" ml={5}>
+          Defikids
+        </Heading>
+      </Flex>
+    );
+  };
+
+  return (
+    <Box h="100vh">
+      {Logo()}
+      <Flex direction="column" align="center" justify="center" h="90vh">
+        <Heading size={"lg"}>Coming Soon</Heading>
+        <Text my={5} color="gray" fontSize="lg">
+          We are working hard to bring you the best experience.
+        </Text>
+      </Flex>
+    </Box>
+  );
+};
+
+export default ComingSoon;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,28 +47,6 @@ function MyApp({ Component, pageProps }) {
     return true;
   };
 
-  if (true) {
-    return (
-      <ChakraProvider
-        theme={theme}
-        toastOptions={{
-          defaultOptions: {
-            position: "bottom",
-            isClosable: true,
-            duration: 4000,
-          },
-        }}
-      >
-        <WagmiConfig config={wagmiConfig}>
-          <RainbowKitProvider chains={chains} modalSize="compact">
-            {/* <Component {...pageProps} /> */}
-            <ComingSoon />
-          </RainbowKitProvider>
-        </WagmiConfig>
-      </ChakraProvider>
-    );
-  }
-
   return (
     <ChakraProvider
       theme={theme}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ import { chains, wagmiConfig } from "@/services/wagmi/wagmiConfig";
 import "@rainbow-me/rainbowkit/styles.css";
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { WagmiConfig } from "wagmi";
+import ComingSoon from "../components/ComingSoon";
 
 function MyApp({ Component, pageProps }) {
   const [hasCheckedUserType, setHasCheckedUserType] = useState(false);
@@ -45,6 +46,28 @@ function MyApp({ Component, pageProps }) {
     if (!isLoggedIn) return false;
     return true;
   };
+
+  if (true) {
+    return (
+      <ChakraProvider
+        theme={theme}
+        toastOptions={{
+          defaultOptions: {
+            position: "bottom",
+            isClosable: true,
+            duration: 4000,
+          },
+        }}
+      >
+        <WagmiConfig config={wagmiConfig}>
+          <RainbowKitProvider chains={chains} modalSize="compact">
+            {/* <Component {...pageProps} /> */}
+            <ComingSoon />
+          </RainbowKitProvider>
+        </WagmiConfig>
+      </ChakraProvider>
+    );
+  }
 
   return (
     <ChakraProvider

--- a/pages/api/ipfs/unpin-from-ipfs.ts
+++ b/pages/api/ipfs/unpin-from-ipfs.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { unpin } from "@/BFF/ipfs/unpin";
+
+export default async function unpinFromIpfsRoute(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { ipfsHash } = req.query as { ipfsHash: string };
+  console.log("ipfsHash - req.query", ipfsHash);
+
+  try {
+    const result = await unpin({ hash: ipfsHash });
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    if (error.reason === "CURRENT_USER_HAS_NOT_PINNED_CID") {
+      return res.status(200).json({ success: true });
+    } else {
+      console.error("Error unpinning file on IPFS:", error);
+      return { mediaError: "Internal Server Error" };
+    }
+  }
+}


### PR DESCRIPTION
I am not sure about this feature because there is an edge case that does exisit where the media that is uploaded to Pinata could be a popular NFT or asset. If this is the case multiple users, especially from the same family could be using the same file which would produce the same IPFS hash. 

Now when a user updates there avatar, they remove the old image hash which would break any other avatar links that may be shared by other users. 

Lets review our Pinata plan and determine the best course of action.